### PR TITLE
build(dev): bump @typescript-eslint from 5.58.0 to 5.59.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.5.0",
-        "@typescript-eslint/eslint-plugin": "^5.58.0",
-        "@typescript-eslint/parser": "^5.58.0",
+        "@typescript-eslint/eslint-plugin": "^5.59.0",
+        "@typescript-eslint/parser": "^5.59.0",
         "eslint": "^8.38.0",
         "eslint-config-prettier": "^8.8.0",
         "eslint-plugin-prettier": "^4.2.1",

--- a/package.json
+++ b/package.json
@@ -45,8 +45,8 @@
   "homepage": "https://github.com/ianprime0509/jest-matcher-percent-error#readme",
   "devDependencies": {
     "@types/jest": "^29.5.0",
-    "@typescript-eslint/eslint-plugin": "^5.58.0",
-    "@typescript-eslint/parser": "^5.58.0",
+    "@typescript-eslint/eslint-plugin": "^5.59.0",
+    "@typescript-eslint/parser": "^5.59.0",
     "eslint": "^8.38.0",
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-prettier": "^4.2.1",


### PR DESCRIPTION
Closes #247
Closes #248

Maybe I should check the actual latest version next time lol